### PR TITLE
Fix issue #8, jcenter dependency only accepts https.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -131,7 +131,7 @@
         <repository>
             <id>jcenter</id>
             <name>jcenter-bintray</name>
-            <url>http://jcenter.bintray.com</url>
+            <url>https://jcenter.bintray.com</url>
         </repository>
     </repositories>
 

--- a/pom.xml
+++ b/pom.xml
@@ -125,6 +125,11 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <version>2.3.0</version>
+        </dependency>
     </dependencies>
 
     <repositories>


### PR DESCRIPTION
Fixes issue #8 

Because I obviously don't know how git pull requests work, both #8 and #10 got merged in the same pull request.

I have not tested that the dependency works with JDK 8 since JDK 8 requires making an account at oracle to download it.